### PR TITLE
Added startup class

### DIFF
--- a/FooService.IISHost/FooService.IISHost.csproj
+++ b/FooService.IISHost/FooService.IISHost.csproj
@@ -95,6 +95,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Startup.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FooService.Contracts\FooService.Contracts.csproj">

--- a/FooService.IISHost/Startup.cs
+++ b/FooService.IISHost/Startup.cs
@@ -1,0 +1,19 @@
+﻿using FooService.IISHost;
+
+[assembly: System.Web.PreApplicationStartMethod(typeof(Startup), "Initialize")]
+namespace FooService.IISHost
+{
+    using Library;
+    using LightInject;
+    using LightInject.Wcf;
+
+    public class Startup
+    {
+        public static void Initialize()
+        {
+            var container = new ServiceContainer();
+            container.RegisterFrom<CompositionRoot>();
+            LightInjectServiceHostFactory.Container = container;
+        }
+    }
+}


### PR DESCRIPTION
Since contracts and implementation are in two different assemblies, we need a startup class to configure from the composition root. 
